### PR TITLE
Speed up build and start up time

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an implementation of the [hotshotco/Hotshot-XL](https://github.com/hotsh
 
 Before running the image, you need to fetch the weights:
 
-    cog run python download-weights.py
+    cog run python ./scripts/download_weights.py
 
 You can then run the image with:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 This is an implementation of the [hotshotco/Hotshot-XL](https://github.com/hotshotco/hotshot-xl) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
-Run predictions:
+## Basic usage
+
+Before running the image, you need to fetch the weights:
+
+    cog run python download-weights.py
+
+You can then run the image with:
 
     cog predict -i prompt="go-pro video of a polar bear diving in the ocean, 8k, HD, dslr, nature footage" -i seed=6226
 

--- a/cog.yaml
+++ b/cog.yaml
@@ -70,9 +70,7 @@ build:
 
   run:
     - apt-get update && apt-get install -y git-lfs ffmpeg
-    - git lfs install
     - git clone https://github.com/hotshotco/Hotshot-XL /Hotshot-XL
-    - git clone https://huggingface.co/hotshotco/SDXL-512 /Hotshot-XL/SDXL-512
 
 
 # predict.py defines how predictions are run on your model

--- a/cog.yaml
+++ b/cog.yaml
@@ -67,10 +67,10 @@ build:
     - "wandb==0.15.11"
     - "zipp==3.17.0"
     - "xformers"
+    - "git+https://github.com/hotshotco/Hotshot-XL"
 
   run:
     - apt-get update && apt-get install -y git-lfs ffmpeg
-    - git clone https://github.com/hotshotco/Hotshot-XL /Hotshot-XL
 
 
 # predict.py defines how predictions are run on your model

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,7 +1,7 @@
 # Configuration for Cog
 build:
   gpu: true
-  cuda: "11.7"
+
   python_version: "3.10"
   python_packages:
     - "accelerate==0.23.0"

--- a/predict.py
+++ b/predict.py
@@ -26,20 +26,16 @@ SCHEDULERS = {
     'EulerDiscreteScheduler': EulerDiscreteScheduler,
 }
 
-MODEL_NAME = "hotshotco/Hotshot-XL"
-MODEL_CACHE = "model-cache"
+HOTSHOTXL_CACHE = "./hotshot-xl"
+
 
 class Predictor(BasePredictor):
     def setup(self) -> None:
         """Load the model into memory to make running multiple predictions efficient"""
-        pipe_line_args = {
-            "torch_dtype": torch.float16,
-            "use_safetensors": True
-        }
         self.pipe = HotshotXLPipeline.from_pretrained(
-            MODEL_NAME, 
-            **pipe_line_args,
-            cache_dir=MODEL_CACHE
+            HOTSHOTXL_CACHE,
+            torch_dtype=torch.float16,
+            use_safetensors=True
         ).to('cuda')
 
     def to_pil_images(self, video_frames: torch.Tensor, output_type='pil'):

--- a/predict.py
+++ b/predict.py
@@ -86,13 +86,6 @@ class Predictor(BasePredictor):
         video_length = 8
         video_duration = 1000
         # scheduler = "EulerAncestralDiscreteScheduler"
-
-        device = torch.device("cuda")
-        pipe_line_args = {
-            "torch_dtype": torch.float16,
-            "use_safetensors": True
-        }
-
         pipe = self.pipe
 
         SchedulerClass = SCHEDULERS[scheduler]

--- a/predict.py
+++ b/predict.py
@@ -26,7 +26,7 @@ SCHEDULERS = {
     'EulerDiscreteScheduler': EulerDiscreteScheduler,
 }
 
-HOTSHOTXL_CACHE = "./hotshot-xl"
+HOTSHOTXL_CACHE = "hotshot-xl"
 
 
 class Predictor(BasePredictor):
@@ -92,14 +92,9 @@ class Predictor(BasePredictor):
             "torch_dtype": torch.float16,
             "use_safetensors": True
         }
-        PipelineClass = HotshotXLPipeline
 
-        pipe = PipelineClass.from_pretrained(
-            MODEL_NAME, 
-            **pipe_line_args,
-            cache_dir=MODEL_CACHE
-        ).to(device)
-        
+        pipe = self.pipe
+
         SchedulerClass = SCHEDULERS[scheduler]
         if SchedulerClass is not None:
             pipe.scheduler = SchedulerClass.from_config(pipe.scheduler.config)

--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-from diffusers import DiffusionPipeline
+from hotshot_xl.pipelines.hotshot_xl_pipeline import HotshotXLPipeline
 import torch
 
-pipe = DiffusionPipeline.from_pretrained(
-    "hotshotco/SDXL-512",
+pipe = HotshotXLPipeline.from_pretrained(
+    "hotshotco/Hotshot-XL",
     torch_dtype=torch.float16,
     use_safetensors=True
 )

--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 from diffusers import DiffusionPipeline
+import torch
 
 pipe = DiffusionPipeline.from_pretrained(
     "hotshotco/SDXL-512",
+    torch_dtype=torch.float16,
+    use_safetensors=True
 )
 
-pipe.save_pretrained("/Hotshot-XL/SDXL-512", safe_serialization=True)
+pipe.save_pretrained("./hotshot-xl", safe_serialization=True)

--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+from diffusers import DiffusionPipeline
+
+pipe = DiffusionPipeline.from_pretrained(
+    "hotshotco/SDXL-512",
+)
+
+pipe.save_pretrained("/Hotshot-XL/SDXL-512", safe_serialization=True)


### PR DESCRIPTION
This PR does speed up the image in a couple of ways:

1. Instead of cloning the model weights with git lfs, which is super slow (and even breaks on my paperspace machine), it uses a script to fetch and prepare the models with diffusers, similar to other cog models. See for example: https://github.com/replicate/cog-sdxl/blob/main/script/download_weights.py
2. The predict.py script created two instances of the pipeline, one in the setup and one in the predict function. I think that's what caused the slow startup time on replicate. You basically have to load all the model weights twice, which takes a lot of time and also probably eats up a lot of memory.

I also removed the fixed cuda version, since you can't actually know on what machine and thus drives the model will be run. I for example was testing it on an A100 instance with cuda 12. 