### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hotshotco/Hotshot-XL Cog model
 
+[![Try a demo on Replicate](https://replicate.com/lucataco/hotshot-xl/badge)](https://replicate.com/lucataco/hotshot-xl)
+
 This is an implementation of the [hotshotco/Hotshot-XL](https://github.com/hotshotco/hotshot-xl) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
 ## Basic usage


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.